### PR TITLE
Limit lsp-origami--parser to modes supporting foldingRangeProvider.

### DIFF
--- a/README.org
+++ b/README.org
@@ -2,5 +2,5 @@
   lsp-origami provides support for ~origami.el~ using language server protocol's
   ~textDocument/foldingRange~ functionality. It can be enabled with
  #+BEGIN_SRC emacs-lisp
- (add-hook 'origami-mode-hook #'lsp-origami-mode)
+ (add-hook 'lsp-after-open-hook #'lsp-origami-try-enable)
  #+END_SRC

--- a/lsp-origami.el
+++ b/lsp-origami.el
@@ -27,7 +27,7 @@
 ;; protocol's "textDocument/foldingRange" functionality.  It can be enabled
 ;; with
 ;; (require 'lsp-origami)
-;; (add-hook 'origami-mode-hook #'lsp-origami-mode)
+;; (add-hook 'lsp-after-open-hook #'lsp-origami-try-enable)
 
 ;;; Code:
 
@@ -36,17 +36,17 @@
 
 (defun lsp-origami--folding-range-to-fold (range create)
   (funcall create
-	   (lsp--folding-range-beg range)
-	   (lsp--folding-range-end range)
-	   0
-	   (seq-map
-	    (lambda (range) (lsp-origami--folding-range-to-fold range create))
-	    (seq-remove (lambda (child-range)
-			  (or (eq (lsp--folding-range-beg child-range)
-				  (lsp--folding-range-beg range))
-			      (eq (lsp--folding-range-end child-range)
-				  (lsp--folding-range-end range))))
-			(lsp--folding-range-children range)))))
+           (lsp--folding-range-beg range)
+           (lsp--folding-range-end range)
+           0
+           (seq-map
+            (lambda (range) (lsp-origami--folding-range-to-fold range create))
+            (seq-remove (lambda (child-range)
+                          (or (eq (lsp--folding-range-beg child-range)
+                                  (lsp--folding-range-beg range))
+                              (eq (lsp--folding-range-end child-range)
+                                  (lsp--folding-range-end range))))
+                        (lsp--folding-range-children range)))))
 
 (defun lsp-origami--parser (create)
   "Get a list of Folding Ranges for the current buffer."
@@ -58,17 +58,29 @@
 	     (lsp--get-nested-folding-ranges))))
 
 ;;;###autoload
+(defun lsp-origami-try-enable ()
+  "Turn on `origami-mode' locally and try to enable `lsp-origami-mode'."
+  (interactive)
+  (origami-mode 1)
+  (cond ((lsp--capability "foldingRangeProvider")
+         (lsp-origami-mode 1))
+        ((called-interactively-p 'any)
+         (signal 'lsp-capability-not-supported (list "foldingRangeProvider")))
+        (t
+         (lsp-log "This server does not support foldingRangeProvider"))))
+
+;;;###autoload
 (define-minor-mode lsp-origami-mode
   "Toggle code folding support for origami."
   :group 'lsp-origami
   :global nil
   (cond
    (lsp-origami-mode
-    (setq-local origami-fold-style 'lsp-mode))
+    (setq-local origami-fold-style 'lsp-mode)
+    (setq-local origami-parser-alist
+                (cons '(lsp-mode . lsp-origami--parser) origami-parser-alist)))
    (t
     (setq-local origami-fold-style nil))))
-
-(push '(lsp-mode . lsp-origami--parser) origami-parser-alist)
 
 (provide 'lsp-origami)
 ;;; lsp-origami.el ends here


### PR DESCRIPTION
This might not be the cleanest way of doing it; I would appreciate any feedback.

Closes #1.

