### PR TITLE
Minor improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# ignore these extensions
+*.elc

--- a/lsp-origami.el
+++ b/lsp-origami.el
@@ -35,6 +35,7 @@
 (require 'lsp-mode)
 
 (defun lsp-origami--folding-range-to-fold (range create)
+  "Executre CREATE callback from origami using RANGE definition."
   (funcall create
            (lsp--folding-range-beg range)
            (lsp--folding-range-end range)
@@ -55,8 +56,8 @@
     (unless (lsp--capability "foldingRangeProvider")
       (signal 'lsp-capability-not-supported (list "foldingRangeProvider")))
     (seq-map (lambda (range)
-	       (lsp-origami--folding-range-to-fold range create))
-	     (lsp--get-nested-folding-ranges))))
+               (lsp-origami--folding-range-to-fold range create))
+             (lsp--get-nested-folding-ranges))))
 
 ;;;###autoload
 (defun lsp-origami-try-enable ()

--- a/lsp-origami.el
+++ b/lsp-origami.el
@@ -35,7 +35,7 @@
 (require 'lsp-mode)
 
 (defun lsp-origami--folding-range-to-fold (range create)
-  "Executre CREATE callback from origami using RANGE definition."
+  "Using the components of RANGE as arguments, execute the CREATE callback."
   (funcall create
            (lsp--folding-range-beg range)
            (lsp--folding-range-end range)


### PR DESCRIPTION
This patch does the following.

* Add minimal `.gitignore` file
* Supply `1` missing docstring.
* Fixed mix use of spaces and tabs.